### PR TITLE
Replace webpack with rspack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# React with TypeScript and Webpack template
+# React with TypeScript and rspack template
 
-This repository serves as a starting point for creating a React application using TypeScript and Webpack.
+This repository serves as a starting point for creating a React application using TypeScript and rspack.
 
 ## Getting started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
                 "@babel/preset-react": "7.24.7",
                 "@babel/preset-typescript": "7.24.7",
                 "@playwright/test": "1.45.3",
+                "@rspack/cli": "0.7.5",
+                "@rspack/core": "0.7.5",
                 "@types/http-server": "0.12.4",
                 "@types/jest": "29.5.12",
                 "@types/react": "18.3.3",
@@ -30,7 +32,6 @@
                 "@typescript-eslint/eslint-plugin": "7.17.0",
                 "@typescript-eslint/parser": "7.17.0",
                 "babel-loader": "9.1.3",
-                "circular-dependency-plugin": "5.2.2",
                 "dotenv": "16.4.5",
                 "eslint": "8.57.0",
                 "eslint-import-resolver-typescript": "3.6.1",
@@ -50,12 +51,8 @@
                 "react-test-renderer": "18.3.1",
                 "rimraf": "6.0.1",
                 "typescript": "5.5.4",
-                "webpack": "5.93.0",
                 "webpack-bundle-analyzer": "4.10.2",
-                "webpack-cli": "5.1.4",
-                "webpack-dev-server": "5.0.4",
-                "webpack-merge": "6.0.1",
-                "webpack-subresource-integrity": "5.1.0"
+                "webpack-merge": "6.0.1"
             },
             "engines": {
                 "node": ">=22.5.1",
@@ -3271,69 +3268,51 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@jsonjoy.com/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.0.4.tgz",
-            "integrity": "sha512-aOcSN4MeAtFROysrbqG137b7gaDDSmVrl5mpo6sT/w+kcXpWnzhMjmY/Fh/sDx26NBxyIE7MB1seqLeCAzy9Sg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jsonjoy.com/base64": "^1.1.1",
-                "@jsonjoy.com/util": "^1.1.2",
-                "hyperdyperid": "^1.2.0",
-                "thingies": "^1.20.0"
-            },
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "node_modules/@jsonjoy.com/util": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.2.0.tgz",
-            "integrity": "sha512-4B8B+3vFsY4eo33DMKyJPlQ3sBMpPFUZK2dr3O3rXrOGKKbYG44J0XSFkDo1VOQiri5HFEhIeVvItjR2xcazmg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
             "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.1.6.tgz",
+            "integrity": "sha512-nj6a+yJ+QxmcE89qmrTl4lphBIoAds0PFPVGnqLRWflwAP88jrCcrrTqRhARegkFDL+wE9AE04+h6jzlbIfMKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.1.6"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.1.6.tgz",
+            "integrity": "sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.1.6",
+                "@module-federation/webpack-bundler-runtime": "0.1.6"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.1.6.tgz",
+            "integrity": "sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.1.6.tgz",
+            "integrity": "sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.1.6",
+                "@module-federation/sdk": "0.1.6"
+            }
         },
         "node_modules/@nicolo-ribaudo/chokidar-2": {
             "version": "2.1.8-no-fsevents.3",
@@ -3422,6 +3401,414 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rspack/binding": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.7.5.tgz",
+            "integrity": "sha512-XcdOvaCz1mWWwr5vmEY9zncdInrjINEh60EWkYdqtCA67v7X7rB1fe6n4BeAI1+YLS2Eacj+lytlr+n7I+DYVg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "0.7.5",
+                "@rspack/binding-darwin-x64": "0.7.5",
+                "@rspack/binding-linux-arm64-gnu": "0.7.5",
+                "@rspack/binding-linux-arm64-musl": "0.7.5",
+                "@rspack/binding-linux-x64-gnu": "0.7.5",
+                "@rspack/binding-linux-x64-musl": "0.7.5",
+                "@rspack/binding-win32-arm64-msvc": "0.7.5",
+                "@rspack/binding-win32-ia32-msvc": "0.7.5",
+                "@rspack/binding-win32-x64-msvc": "0.7.5"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.7.5.tgz",
+            "integrity": "sha512-mNBIm36s1BA7v4SL/r4f3IXIsjyH5CZX4eXMRPE52lBc3ClVuUB7d/8zk8dkyjJCMAj8PsZSnAJ3cfXnn7TN4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.7.5.tgz",
+            "integrity": "sha512-teLK0TB1x0CsvaaiCopsFx4EvJe+/Hljwii6R7C9qOZs5zSOfbT/LQ202eA0sAGodCncARCGaXVrsekbrRYqeA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.7.5.tgz",
+            "integrity": "sha512-/24UytJXrK+7CsucDb30GCKYIJ8nG6ceqbJyOtsJv9zeArNLHkxrYGSyjHJIpQfwVN17BPP4RNOi+yIZ3ZgDyA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.7.5.tgz",
+            "integrity": "sha512-6RcxG42mLM01Pa6UYycACu/Nu9qusghAPUJumb8b8x5TRIDEtklYC5Ck6Rmagm+8E0ucMude2E/D4rMdIFcS3A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.7.5.tgz",
+            "integrity": "sha512-R0Lu4CJN2nWMW7WzPBuCIju80cQPpcaqwKJDj/quwQySpJJZ6c5qGwB8mntqjxIzZDrNH6u0OkpiUTbvWZj8ww==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.7.5.tgz",
+            "integrity": "sha512-dDgi/ThikMy1m4llxPeEXDCA2I8F8ezFS/eCPLZGU2/J1b4ALwDjuRsMmo+VXSlFCKgIt98V6h1woeg7nu96yg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.7.5.tgz",
+            "integrity": "sha512-nEF4cUdLfgEK6FrgJSJhUlr2/7LY1tmqBNQCFsCjtDtUkQbJIEo1b8edT94G9tJcQoFE4cD+Re30yBYbQO2Thg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.7.5.tgz",
+            "integrity": "sha512-hEcHRwJIzpZsePr+5x6V/7TGhrPXhSZYG4sIhsrem1za9W+qqCYYLZ7KzzbRODU07QaAH2RxjcA1bf8F2QDYAQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.7.5.tgz",
+            "integrity": "sha512-PpVpP6J5/2b4T10hzSUwjLvmdpAOj3ozARl1Nrf/lsbYwhiXivoB8Gvoy/xe/Xpgr732Dk9VCeeW8rreWOOUVQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/cli": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-0.7.5.tgz",
+            "integrity": "sha512-3Lp1RSyTRzBUi232hjRmF6wLHaMJXXMJIlX5dR662HwfCRwgm+q/Nz3829/UbjHXI2aGN4fFBgNI+LJU1TOZVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@discoveryjs/json-ext": "^0.5.7",
+                "@rspack/dev-server": "0.7.5",
+                "colorette": "2.0.19",
+                "exit-hook": "^3.2.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "semver": "6.3.1",
+                "webpack-bundle-analyzer": "4.6.1",
+                "yargs": "17.6.2"
+            },
+            "bin": {
+                "rspack": "bin/rspack"
+            },
+            "peerDependencies": {
+                "@rspack/core": ">=0.4.0"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rspack/cli/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/mrmime": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+            "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/sirv": {
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+            "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.20",
+                "mrmime": "^1.0.0",
+                "totalist": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/totalist": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+            "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/webpack-bundle-analyzer": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz",
+            "integrity": "sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.0.4",
+                "acorn-walk": "^8.0.0",
+                "chalk": "^4.1.0",
+                "commander": "^7.2.0",
+                "gzip-size": "^6.0.0",
+                "lodash": "^4.17.20",
+                "opener": "^1.5.2",
+                "sirv": "^1.0.7",
+                "ws": "^7.3.1"
+            },
+            "bin": {
+                "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/core": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.7.5.tgz",
+            "integrity": "sha512-zVTe4WCyc3qsLPattosiDYZFeOzaJ32/BYukPP2I1VJtCVFa+PxGVRPVZhSoN6fXw5oy48yHg9W9v1T8CaEFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.1.6",
+                "@rspack/binding": "0.7.5",
+                "caniuse-lite": "^1.0.30001616",
+                "tapable": "2.2.1",
+                "webpack-sources": "3.2.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/dev-server": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-0.7.5.tgz",
+            "integrity": "sha512-jDXfccjlHMXOxOK++uxWhLUKb0L3NuA6Ujc/J75NhWYq1YxmVhNOtUWCdunuJQ1BNeLlgG/S5X5iBCbZ09S0Jg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "3.5.3",
+                "connect-history-api-fallback": "2.0.0",
+                "express": "4.19.2",
+                "http-proxy-middleware": "2.0.6",
+                "mime-types": "2.1.35",
+                "webpack-dev-middleware": "6.1.2",
+                "webpack-dev-server": "4.13.1",
+                "ws": "8.8.1"
+            },
+            "peerDependencies": {
+                "@rspack/core": "*"
+            }
+        },
+        "node_modules/@rspack/dev-server/node_modules/chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -3554,6 +3941,7 @@
             "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -3565,6 +3953,7 @@
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -3575,7 +3964,8 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/express": {
             "version": "4.17.21",
@@ -3791,9 +4181,9 @@
             }
         },
         "node_modules/@types/retry": {
-            "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4107,6 +4497,7 @@
             "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.6",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
@@ -4117,21 +4508,24 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
             "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
             "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.12.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
             "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.6",
@@ -4139,6 +4533,7 @@
             "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.6",
                 "@webassemblyjs/helper-api-error": "1.11.6",
@@ -4150,7 +4545,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
             "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.12.1",
@@ -4158,6 +4554,7 @@
             "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-buffer": "1.12.1",
@@ -4171,6 +4568,7 @@
             "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -4181,6 +4579,7 @@
             "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -4190,7 +4589,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
             "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.12.1",
@@ -4198,6 +4598,7 @@
             "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-buffer": "1.12.1",
@@ -4215,6 +4616,7 @@
             "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
@@ -4229,6 +4631,7 @@
             "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-buffer": "1.12.1",
@@ -4242,6 +4645,7 @@
             "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-api-error": "1.11.6",
@@ -4257,56 +4661,10 @@
             "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webpack-cli/configtest": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
-            "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.15.0"
-            },
-            "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
-            }
-        },
-        "node_modules/@webpack-cli/info": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
-            "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.15.0"
-            },
-            "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
-            }
-        },
-        "node_modules/@webpack-cli/serve": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
-            "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.15.0"
-            },
-            "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
-            },
-            "peerDependenciesMeta": {
-                "webpack-dev-server": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -4314,14 +4672,16 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -4375,6 +4735,7 @@
             "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^8"
             }
@@ -4480,6 +4841,7 @@
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
@@ -5081,6 +5443,13 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/basic-auth/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5126,16 +5495,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/body-parser/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/body-parser/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5152,22 +5511,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/bonjour-service": {
             "version": "1.2.1",
@@ -5260,26 +5603,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/bundle-name": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "run-applescript": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5414,6 +5741,7 @@
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -5432,19 +5760,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/circular-dependency-plugin": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
-            "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "peerDependencies": {
-                "webpack": ">=4.0.1"
             }
         },
         "node_modules/cjs-module-lexer": {
@@ -5533,9 +5848,9 @@
             "license": "MIT"
         },
         "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5601,6 +5916,16 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/compression/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/compression/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5615,6 +5940,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/compression/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
             "license": "MIT"
         },
@@ -5647,27 +5979,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/content-disposition/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/content-type": {
             "version": "1.0.5",
@@ -6084,36 +6395,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/default-browser": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bundle-name": "^4.1.0",
-                "default-browser-id": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/default-gateway": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -6146,16 +6427,13 @@
             }
         },
         "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/define-properties": {
@@ -6475,19 +6753,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/envinfo": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-            "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "envinfo": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -6634,7 +6899,8 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
             "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.0.0",
@@ -7605,6 +7871,7 @@
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -7640,6 +7907,19 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/exit-hook": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-3.2.0.tgz",
+            "integrity": "sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/expect": {
@@ -7719,43 +7999,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/express/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7800,16 +8043,6 @@
             "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fastest-levenshtein": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.9.1"
-            }
         },
         "node_modules/fastq": {
             "version": "1.17.1",
@@ -8085,6 +8318,13 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs-monkey": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
+            "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
+            "dev": true,
+            "license": "Unlicense"
+        },
         "node_modules/fs-readdir-recursive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -8287,7 +8527,8 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -8554,6 +8795,13 @@
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
             }
+        },
+        "node_modules/hpack.js/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/hpack.js/node_modules/string_decoder": {
             "version": "1.1.1",
@@ -8911,16 +9159,6 @@
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/hyperdyperid": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.18"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9105,13 +9343,13 @@
             }
         },
         "node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 0.10"
             }
         },
         "node_modules/is-arguments": {
@@ -9276,16 +9514,16 @@
             }
         },
         "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -9363,25 +9601,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -9406,19 +9625,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-network-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
-            "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-number": {
@@ -9641,19 +9847,16 @@
             }
         },
         "node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-inside-container": "^1.0.0"
+                "is-docker": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -11662,6 +11865,28 @@
                 }
             }
         },
+        "node_modules/jsdom/node_modules/ws": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -11830,6 +12055,7 @@
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -11948,23 +12174,16 @@
             }
         },
         "node_modules/memfs": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.9.4.tgz",
-            "integrity": "sha512-Xlj8b2rU11nM6+KU6wC7cuWcHQhVINWCUgdPS4Ar9nPxLaOya3RghqK7ALyDW2QtGebYAYs6uEdEVnwPVT942A==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+            "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
             "dev": true,
-            "license": "Apache-2.0",
+            "license": "Unlicense",
             "dependencies": {
-                "@jsonjoy.com/json-pack": "^1.0.3",
-                "@jsonjoy.com/util": "^1.1.2",
-                "tree-dump": "^1.0.1",
-                "tslib": "^2.0.0"
+                "fs-monkey": "^1.0.4"
             },
             "engines": {
                 "node": ">= 4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
             }
         },
         "node_modules/merge-descriptors": {
@@ -12170,7 +12389,8 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -12443,19 +12663,18 @@
             }
         },
         "node_modules/open": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.2.1",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -12522,21 +12741,17 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
-            "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/retry": "0.12.2",
-                "is-network-error": "^1.0.0",
+                "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/p-try": {
@@ -13059,16 +13274,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/proxy-addr/node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -13104,13 +13309,13 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
-            "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.0.4"
             },
             "engines": {
                 "node": ">=0.6"
@@ -13153,6 +13358,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -13179,16 +13385,6 @@
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -13648,19 +13844,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/run-applescript": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13705,10 +13888,24 @@
             }
         },
         "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "license": "MIT"
         },
         "node_modules/safe-regex-test": {
@@ -13908,6 +14105,7 @@
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -14287,27 +14485,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -14596,6 +14773,7 @@
             "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.20",
                 "jest-worker": "^27.4.5",
@@ -14631,6 +14809,7 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14641,6 +14820,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -14656,6 +14836,7 @@
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -14675,6 +14856,7 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -14748,19 +14930,6 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/thingies": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-            "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-            "dev": true,
-            "license": "Unlicense",
-            "engines": {
-                "node": ">=10.18"
-            },
-            "peerDependencies": {
-                "tslib": "^2"
-            }
         },
         "node_modules/thunky": {
             "version": "1.1.0",
@@ -14846,23 +15015,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/tree-dump": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
-            "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
             }
         },
         "node_modules/ts-api-utils": {
@@ -15070,13 +15222,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/typed-assert": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/typed-assert/-/typed-assert-1.0.9.tgz",
-            "integrity": "sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/typescript": {
             "version": "5.5.4",
@@ -15338,6 +15483,7 @@
             "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -15378,6 +15524,7 @@
             "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
@@ -15492,93 +15639,21 @@
                 }
             }
         },
-        "node_modules/webpack-cli": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
-            "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^2.1.1",
-                "@webpack-cli/info": "^2.0.2",
-                "@webpack-cli/serve": "^2.0.5",
-                "colorette": "^2.0.14",
-                "commander": "^10.0.1",
-                "cross-spawn": "^7.0.3",
-                "envinfo": "^7.7.3",
-                "fastest-levenshtein": "^1.0.12",
-                "import-local": "^3.0.2",
-                "interpret": "^3.1.1",
-                "rechoir": "^0.8.0",
-                "webpack-merge": "^5.7.3"
-            },
-            "bin": {
-                "webpack-cli": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=14.15.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "5.x.x"
-            },
-            "peerDependenciesMeta": {
-                "@webpack-cli/generators": {
-                    "optional": true
-                },
-                "webpack-bundle-analyzer": {
-                    "optional": true
-                },
-                "webpack-dev-server": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-cli/node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/webpack-cli/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/webpack-dev-middleware": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.3.0.tgz",
-            "integrity": "sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+            "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^4.6.0",
+                "memfs": "^3.4.12",
                 "mime-types": "^2.1.31",
-                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 14.15.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -15594,55 +15669,55 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.4.tgz",
-            "integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
+            "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/bonjour": "^3.5.13",
-                "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.21",
-                "@types/serve-index": "^1.9.4",
-                "@types/serve-static": "^1.15.5",
-                "@types/sockjs": "^0.3.36",
-                "@types/ws": "^8.5.10",
+                "@types/bonjour": "^3.5.9",
+                "@types/connect-history-api-fallback": "^1.3.5",
+                "@types/express": "^4.17.13",
+                "@types/serve-index": "^1.9.1",
+                "@types/serve-static": "^1.13.10",
+                "@types/sockjs": "^0.3.33",
+                "@types/ws": "^8.5.1",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.2.1",
-                "chokidar": "^3.6.0",
+                "bonjour-service": "^1.0.11",
+                "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^2.0.0",
                 "default-gateway": "^6.0.3",
                 "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.4.0",
+                "html-entities": "^2.3.2",
                 "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
-                "open": "^10.0.3",
-                "p-retry": "^6.2.0",
-                "rimraf": "^5.0.5",
-                "schema-utils": "^4.2.0",
-                "selfsigned": "^2.4.1",
+                "ipaddr.js": "^2.0.1",
+                "launch-editor": "^2.6.0",
+                "open": "^8.0.9",
+                "p-retry": "^4.5.0",
+                "rimraf": "^3.0.2",
+                "schema-utils": "^4.0.0",
+                "selfsigned": "^2.1.1",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^7.1.0",
-                "ws": "^8.16.0"
+                "webpack-dev-middleware": "^5.3.1",
+                "ws": "^8.13.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 12.13.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": "^4.37.0 || ^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -15653,84 +15728,77 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+        "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/webpack-dev-server/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": ">= 10"
             }
         },
         "node_modules/webpack-dev-server/node_modules/rimraf": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.9.tgz",
-            "integrity": "sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "glob": "^10.3.7"
+                "glob": "^7.1.3"
             },
             "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "14 >=14.20 || 16 >=16.20 || >=18"
+                "rimraf": "bin.js"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.10",
+                "memfs": "^3.4.3",
+                "mime-types": "^2.1.31",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/ws": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-merge": {
@@ -15758,34 +15826,13 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webpack-subresource-integrity": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-5.1.0.tgz",
-            "integrity": "sha512-sacXoX+xd8r4WKsy9MvH/q/vBtEHr86cpImXwyg74pFIpERKt6FmB8cXpeuh0ZLgclOlHI4Wcll7+R5L02xk9Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "typed-assert": "^1.0.8"
-            },
-            "engines": {
-                "node": ">= 12"
-            },
-            "peerDependencies": {
-                "html-webpack-plugin": ">= 5.0.0-beta.1 < 6",
-                "webpack": "^5.12.0"
-            },
-            "peerDependenciesMeta": {
-                "html-webpack-plugin": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/webpack/node_modules/eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -15800,6 +15847,7 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -15810,6 +15858,7 @@
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -16145,9 +16194,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+            "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16155,7 +16204,7 @@
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
+                "utf-8-validate": "^5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -16201,9 +16250,9 @@
             "license": "ISC"
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "react-typescript-boilerplate",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "react-typescript-boilerplate",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-typescript-boilerplate",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "license": "MIT",
     "private": true,
     "author": "Tamas Mezei",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "test:e2e:check": "playwright test",
         "test:e2e:update": "playwright test --update-snapshots",
         "audit:check": "npm audit --package-lock-only --omit=dev",
-        "build": "webpack --config webpack.config.js",
+        "build": "rspack --config rspack.config.js",
         "serve": "http-server ./dist/bundle/ --port 8080",
-        "start": "webpack serve --config webpack.serve.config.js"
+        "start": "rspack serve --config rspack.serve.config.js"
     },
     "dependencies": {
         "react": "18.3.1",
@@ -43,6 +43,8 @@
         "@babel/preset-react": "7.24.7",
         "@babel/preset-typescript": "7.24.7",
         "@playwright/test": "1.45.3",
+        "@rspack/cli": "0.7.5",
+        "@rspack/core": "0.7.5",
         "@types/http-server": "0.12.4",
         "@types/jest": "29.5.12",
         "@types/react": "18.3.3",
@@ -51,7 +53,6 @@
         "@typescript-eslint/eslint-plugin": "7.17.0",
         "@typescript-eslint/parser": "7.17.0",
         "babel-loader": "9.1.3",
-        "circular-dependency-plugin": "5.2.2",
         "dotenv": "16.4.5",
         "eslint": "8.57.0",
         "eslint-import-resolver-typescript": "3.6.1",
@@ -71,11 +72,7 @@
         "react-test-renderer": "18.3.1",
         "rimraf": "6.0.1",
         "typescript": "5.5.4",
-        "webpack": "5.93.0",
         "webpack-bundle-analyzer": "4.10.2",
-        "webpack-cli": "5.1.4",
-        "webpack-dev-server": "5.0.4",
-        "webpack-merge": "6.0.1",
-        "webpack-subresource-integrity": "5.1.0"
+        "webpack-merge": "6.0.1"
     }
 }

--- a/rspack.common.config.js
+++ b/rspack.common.config.js
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('node:path');
 
-const CircularDependencyPlugin = require('circular-dependency-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const packageJson = require('./package.json');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const webpackCommonConfig = {
+const rspackCommonConfig = {
     target: 'web',
     bail: true,
     devtool: 'source-map',
@@ -39,18 +38,9 @@ const webpackCommonConfig = {
         new HtmlWebpackPlugin({
             template: './src/index.html',
             title: packageJson.name
-        }),
-
-        new CircularDependencyPlugin({
-            exclude: /node_modules/,
-            include: /src/,
-            failOnError: true,
-            allowAsyncCycles: false,
-            cwd: process.cwd()
         })
     ],
     optimization: {
-        emitOnErrors: false,
         splitChunks: {
             chunks: 'all'
         }
@@ -60,4 +50,4 @@ const webpackCommonConfig = {
     }
 };
 
-module.exports = webpackCommonConfig;
+module.exports = rspackCommonConfig;

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -1,21 +1,16 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const { merge } = require('webpack-merge');
-const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 
-const webpackCommonConfig = require('./webpack.common.config');
+const rspackCommonConfig = require('./rspack.common.config');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const webpackConfig = {
+const rspackConfig = {
     mode: 'production',
     output: {
         crossOriginLoading: 'anonymous'
     },
     plugins: [
-        new SubresourceIntegrityPlugin({
-            hashFuncNames: ['sha256', 'sha384', 'sha512']
-        }),
-
         new BundleAnalyzerPlugin({
             openAnalyzer: false,
             analyzerMode: 'static',
@@ -26,4 +21,4 @@ const webpackConfig = {
     ]
 };
 
-module.exports = merge(webpackCommonConfig, webpackConfig);
+module.exports = merge(rspackCommonConfig, rspackConfig);

--- a/rspack.serve.config.js
+++ b/rspack.serve.config.js
@@ -2,13 +2,13 @@
 const dotenv = require('dotenv');
 const { merge } = require('webpack-merge');
 
-const webpackCommonConfig = require('./webpack.common.config');
+const rspackCommonConfig = require('./rspack.common.config');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 // Prepare the environtment variables
 dotenv.config();
 
-const webpackServeConfig = {
+const rspackServeConfig = {
     mode: 'development',
     devServer: {
         port: process.env.APP_DEV_SERVER_PORT,
@@ -18,4 +18,4 @@ const webpackServeConfig = {
     }
 };
 
-module.exports = merge(webpackCommonConfig, webpackServeConfig);
+module.exports = merge(rspackCommonConfig, rspackServeConfig);


### PR DESCRIPTION
This PR intends to replace [`webpack`](https://webpack.js.org/) with [`rspack`](https://www.rspack.dev/) to speed up the bundling. The goal is to migrate with the least amount of work, using the systems already in place.

## Tasks
- [x] Add `@rspack/core` and `@rspack/cli` to `devDependencies`
- [x] Remove `webpack`, `webpack-cli` and `webpack-dev-server` from `devDependencies`
- [x] Migrate `webpack` configs:
  - [x] Remove the `circular-dependency-plugin` and the `webpack-subresource-integrity` `webpack` plugins due compatibility issues
  - [x] Remove the `emitOnErrors: false` config from `optimization`
  - [x] Rename variable names
- [x] Update `README.md`
- [x] Bump version number to `2.0.0` in `package.json` 

## Notes
- Unfortunately the `circular-dependency-plugin` and the `webpack-subresource-integrity` `webpack` plugins are not compatible with `rspack`

## Additional resources
- Migration guide from `webpack`: https://www.rspack.dev/guide/migration/webpack
- `rspack` `webpack` plugin compatibility: https://www.rspack.dev/guide/compatibility/plugin
