### PR TITLE
Fix bundle report upload

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: unit-test-reports
+          name: reports-unit-test
           path: reports/tests/unit/
           retention-days: 3
 
@@ -123,6 +123,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: e2e-test-reports
+          name: reports-e2e-test
           path: reports/tests/e2e/
           retention-days: 3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,7 +84,8 @@ jobs:
         if: always()
         with:
           name: reports-bundle
-          path: reports/bundle/
+          include-hidden-files: true
+          path: reports/bundle/.rsdoctor/
           retention-days: 3
 
   test:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         with:
           name: bundle-reports
-          path: reports/bundle/.rsdoctor/
+          path: reports/bundle/
           retention-days: 3
 
       - name: Upload bundle reports

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,14 +83,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: bundle-reports
-          path: reports/bundle/
-          retention-days: 3
-
-      - name: Upload bundle reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
           name: reports-bundle
           path: reports/bundle/
           retention-days: 3


### PR DESCRIPTION
This PR intends to fix the bundle report uploading.

## Tasks
- [x] Fix the bundle report uploading
  - [x] Remove duplication
  - [x] Add `include-hidden-files: true` in order to be able to upload the `.rsdoctor` folder
- [x] Make the upload names consistent
