### PR TITLE
Add dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "@testing-library/react": "16.3.0",
                 "@types/react": "19.1.12",
                 "@types/react-dom": "19.1.8",
+                "dotenv": "17.2.1",
                 "eslint": "9.34.0",
                 "eslint-plugin-react": "7.37.5",
                 "jsdom": "26.1.0",
@@ -3461,6 +3462,19 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+            "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@testing-library/react": "16.3.0",
         "@types/react": "19.1.12",
         "@types/react-dom": "19.1.8",
+        "dotenv": "17.2.1",
         "eslint": "9.34.0",
         "eslint-plugin-react": "7.37.5",
         "jsdom": "26.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+
+config();
 
 export default defineConfig({
     testDir: './tests',

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -3,6 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { CircularDependencyRspackPlugin, experiments } from '@rspack/core';
+import { config } from 'dotenv';
+
+config();
 
 const { SubresourceIntegrityPlugin } = experiments;
 


### PR DESCRIPTION
This PR intends to add back the `dotenv` library as it was removed accidentally.

## Tasks
- [x] Add `dotenv` library as a dependency
- [x] Inject variables into
  - [x] `rsbuild.config.ts`
  - [x] `playwright.config.ts`
