### PR TITLE
Remove explicit React import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -217,12 +217,7 @@ export default pluginTs.config(
                     forms: false
                 }
             ],
-            'react/jsx-no-undef': [
-                'error',
-                {
-                    allowGlobals: false
-                }
-            ],
+            'react/jsx-no-undef': 'off',
             'react/jsx-no-useless-fragment': [
                 'error',
                 {
@@ -357,7 +352,7 @@ export default pluginTs.config(
                     skipUndeclared: false
                 }
             ],
-            'react/react-in-jsx-scope': 'error',
+            'react/react-in-jsx-scope': 'off',
             'react/require-default-props': 'off',
             'react/require-optimization': 'off',
             'react/require-render-return': 'error',

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { describe, test, expect } from '@rstest/core';
 import { render } from '@testing-library/react';
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { FunctionComponent, ReactElement } from 'react';
 
 import { Dummy } from '@/shared';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -18,11 +17,11 @@ if (rootElement === null) {
 const root = createRoot(rootElement);
 
 root.render(
-    <React.StrictMode>
+    <StrictMode>
         <BrowserRouter>
             <App />
         </BrowserRouter>
-    </React.StrictMode>
+    </StrictMode>
 );
 
 addWebVitalsReporting();

--- a/src/shared/dummy/Dummy.test.tsx
+++ b/src/shared/dummy/Dummy.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { describe, test, expect } from '@rstest/core';
 import { render } from '@testing-library/react';
 

--- a/src/shared/dummy/Dummy.tsx
+++ b/src/shared/dummy/Dummy.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { FunctionComponent, ReactElement } from 'react';
 
 type DummyProps = {


### PR DESCRIPTION
This PR intends to remove all explicit React imports. The project is using version 19 of React, so it is not needed anymore.

## Tasks
- [x] Remove all explicit React imports (`import React from 'react';`)
- [x] Switch off related ESLint rules
