### PR TITLE
Remove resolve alias

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -56,9 +56,7 @@ export default defineConfig({
         }
     },
     resolve: {
-        alias: {
-            '@/shared': './src/shared'
-        }
+        aliasStrategy: 'prefer-tsconfig'
     },
     output: {
         cleanDistPath: true,


### PR DESCRIPTION
This PR intends remove the redundant alias configuration from the `rsbuild.config.ts` in favor of `tsconfig.json`

## Tasks
- [x] Remove the `resolve.alias`
- [x] Add the `resolve.aliasStrategy` to signal that the `tsconfig.json` will be the source for aliases