### PR TITLE
Add code coverage report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "@rsbuild/plugin-svgr": "1.2.2",
                 "@rsdoctor/rspack-plugin": "1.3.1",
                 "@rstest/core": "0.5.0",
+                "@rstest/coverage-istanbul": "0.0.3",
                 "@tailwindcss/postcss": "4.1.13",
                 "@testing-library/jest-dom": "6.8.0",
                 "@testing-library/react": "16.3.0",
@@ -896,6 +897,16 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1695,6 +1706,23 @@
                 "@swc/helpers": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@rstest/coverage-istanbul": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@rstest/coverage-istanbul/-/coverage-istanbul-0.0.3.tgz",
+            "integrity": "sha512-hQjGM1bKgYZfX0zPaF5URjCPAdB3rZs8t62l24iGXQvoYfgCEJA9bvm+KcS2h4O4159E2Z8LetcN2s7Cc+7PtA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-instrument": "5.2.1",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "swc-plugin-coverage-instrument": "^0.0.31"
+            },
+            "peerDependencies": {
+                "@rstest/core": "~0.5.0"
             }
         },
         "node_modules/@socket.io/component-emitter": {
@@ -4897,6 +4925,13 @@
             ],
             "license": "MIT"
         },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5428,6 +5463,72 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/core": "^7.12.3",
+                "@babel/parser": "^7.14.7",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/iterator.prototype": {
             "version": "1.1.5",
@@ -5995,6 +6096,22 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/math-intrinsics": {
@@ -7731,6 +7848,13 @@
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
             "dev": true,
             "license": "CC0-1.0"
+        },
+        "node_modules/swc-plugin-coverage-instrument": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/swc-plugin-coverage-instrument/-/swc-plugin-coverage-instrument-0.0.31.tgz",
+            "integrity": "sha512-Q26/ZOqk102VJ+sN5X/mab4WEtzYNRTcnV3VccrANDKRImdgjjyTpo7tH1mTxS6zopHrmZ9S0jAUeyYlT7xO7A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/symbol-tree": {
             "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@rsbuild/plugin-svgr": "1.2.2",
         "@rsdoctor/rspack-plugin": "1.3.1",
         "@rstest/core": "0.5.0",
+        "@rstest/coverage-istanbul": "0.0.3",
         "@tailwindcss/postcss": "4.1.13",
         "@testing-library/jest-dom": "6.8.0",
         "@testing-library/react": "16.3.0",

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
                     new RsdoctorRspackPlugin({
                         disableClientServer: true,
                         features: ['loader', 'plugins', 'bundle'],
-                        mode: 'brief',
                         output: {
+                            mode: 'brief',
                             reportDir: `${__dirname}/reports/bundle/`
                         },
                         brief: {

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -5,5 +5,14 @@ export default defineConfig({
     plugins: [pluginReact()],
     include: ['src/**/*.test.tsx'],
     testEnvironment: 'jsdom',
-    reporters: ['verbose', 'github-actions']
+    reporters: ['verbose', 'github-actions'],
+    coverage: {
+        enabled: true,
+        clean: true,
+        provider: 'istanbul',
+        reporters: ['text', 'html', 'clover', 'json'],
+        reportsDirectory: `./reports/tests/unit/coverage`,
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: ['src/**/index.{ts,tsx}', '**/*.config.[c|m][jt]s']
+    }
 });


### PR DESCRIPTION
This PR intends add code coverage reports upon executing unit tests and also move the `mode: 'brief'` under `output` `Rsdoctor` config.

## Tasks
- `Rstest`
  - Add coverage report configuration
- `Rsdoctor`
  - Move the `mode: 'brief'` under `output`

## Notes
- https://rstest.rs/config/test/coverage
